### PR TITLE
Fix NT Picnic Day: first Monday of August (DEV-30999)

### DIFF
--- a/definitions/au.yaml
+++ b/definitions/au.yaml
@@ -203,7 +203,7 @@ methods:
     arguments: year
     source: |
       if year >= 2025
-        Date.civil(year, 8, 4)
+        DateCalculatorFactory.day_of_month_calculator.call(year, 8, :first, :monday)
       end
   qld_queens_bday_october:
     # http://www.justice.qld.gov.au/fair-and-safe-work/industrial-relations/public-holidays/dates
@@ -367,6 +367,12 @@ tests: |
     # ANZAC Day 2026-2027 - NSW observes on Monday when ANZAC Day falls on weekend
     assert_equal "ANZAC Day", Date.civil(2026, 4, 27).holidays(:au_nsw, :observed)[0][:name]
     assert_equal "ANZAC Day", Date.civil(2027, 4, 26).holidays(:au_nsw, :observed)[0][:name]
+
+    # NT Picnic Day - first Monday of August (not a fixed date). Regression: DEV-30999
+    assert_equal "Picnic Day", Date.civil(2025, 8, 4).holidays(:au_nt)[0][:name]
+    assert_equal "Picnic Day", Date.civil(2026, 8, 3).holidays(:au_nt)[0][:name]
+    assert_equal "Picnic Day", Date.civil(2027, 8, 2).holidays(:au_nt)[0][:name]
+    assert_equal [], Date.civil(2026, 8, 4).holidays(:au_nt)
 
     # BOXING DAY - QLD observes weekend and monday
     assert_equal "Boxing Day", Date.civil(2015, 12, 26).holidays(:au_qld)[0][:name]

--- a/lib/generated_definitions/au.rb
+++ b/lib/generated_definitions/au.rb
@@ -87,7 +87,7 @@ end
 
 "picnic_day_from_2025(year)" => Proc.new { |year|
 if year >= 2025
-  Date.civil(year, 8, 4)
+  DateCalculatorFactory.day_of_month_calculator.call(year, 8, :first, :monday)
 end
 },
 

--- a/test/defs/test_defs_au.rb
+++ b/test/defs/test_defs_au.rb
@@ -98,6 +98,12 @@ assert_equal "ANZAC Day", Date.civil(2015, 4, 27).holidays(:au_wa, :observed)[0]
 assert_equal "ANZAC Day", Date.civil(2026, 4, 27).holidays(:au_nsw, :observed)[0][:name]
 assert_equal "ANZAC Day", Date.civil(2027, 4, 26).holidays(:au_nsw, :observed)[0][:name]
 
+# NT Picnic Day - first Monday of August (not a fixed date). Regression: DEV-30999
+assert_equal "Picnic Day", Date.civil(2025, 8, 4).holidays(:au_nt)[0][:name]
+assert_equal "Picnic Day", Date.civil(2026, 8, 3).holidays(:au_nt)[0][:name]
+assert_equal "Picnic Day", Date.civil(2027, 8, 2).holidays(:au_nt)[0][:name]
+assert_equal [], Date.civil(2026, 8, 4).holidays(:au_nt)
+
 # BOXING DAY - QLD observes weekend and monday
 assert_equal "Boxing Day", Date.civil(2015, 12, 26).holidays(:au_qld)[0][:name]
 assert_equal "Boxing Day", Date.civil(2015, 12, 28).holidays(:au_qld, :observed)[0][:name]


### PR DESCRIPTION
## Problem

NT **Picnic Day** (`au_nt`) is defined with a hardcoded date:

```ruby
picnic_day_from_2025 => Date.civil(year, 8, 4)
```

Picnic Day is legislated as the **first Monday of August**. The hardcoded 4th only coincidentally matched reality in 2025 (4 Aug 2025 *was* the first Monday). It resolves incorrectly for:

| Year | Was (hardcoded) | Correct (1st Mon Aug) |
|------|-----------------|------------------------|
| 2025 | Mon 4 Aug ✅ | Mon 4 Aug |
| 2026 | **Tue 4 Aug ❌** | **Mon 3 Aug** |
| 2027 | Wed 4 Aug ❌ | Mon 2 Aug |

This feeds ShiftCare's auto-populated public holidays → payroll/timesheets for all NT accounts. Reported via escalation DEV-30999 (account Being Mentors NT).

## Fix

Compute the first Monday of August using `DateCalculatorFactory.day_of_month_calculator`, mirroring the existing `qld_queens_bday_october` definition in the same file. The `year >= 2025` gate is preserved, so pre-2025 historical data is unchanged.

```ruby
DateCalculatorFactory.day_of_month_calculator.call(year, 8, :first, :monday)
```

## Tests

Added regression assertions to `au.yaml` (`tests:` block) and regenerated `test/defs/test_defs_au.rb`:

```ruby
assert_equal "Picnic Day", Date.civil(2025, 8, 4).holidays(:au_nt)[0][:name]
assert_equal "Picnic Day", Date.civil(2026, 8, 3).holidays(:au_nt)[0][:name]
assert_equal "Picnic Day", Date.civil(2027, 8, 2).holidays(:au_nt)[0][:name]
assert_equal [], Date.civil(2026, 8, 4).holidays(:au_nt)   # the old hardcoded-4th bug
```

The AU defs test passes (109 assertions, 0 failures). The 8 pre-existing suite failures are unrelated US/CA definition drift (identical count on the base branch).

## Notes

- Base branch is `holidays-april-16-2025` (the branch the app's `Gemfile` pins), following PR #13.
- Diff is scoped to `au.yaml`, `au.rb`, `test/defs/test_defs_au.rb`. Unrelated `rake generate` churn in `REGIONS.rb`/`nz.rb` was excluded.
- Follow-up (separate): Melbourne Cup missing for VIC-Melbourne accounts — likely an app-side region-mapping issue, not this gem.